### PR TITLE
made the power kw to ship as integer

### DIFF
--- a/src/india_api/internal/inputs/indiadb/client.py
+++ b/src/india_api/internal/inputs/indiadb/client.py
@@ -94,7 +94,7 @@ class Client(internal.DatabaseInterface):
         # convert from GenerationSQL to PredictedPower
         values = [
             internal.ActualPower(
-                PowerKW=value.generation_power_kw, Time=value.start_utc.astimezone(dt.UTC)
+                PowerKW=int(value.generation_power_kw), Time=value.start_utc.astimezone(dt.UTC)
             )
             for value in values
         ]


### PR DESCRIPTION



# Pull Request

## Description
made the value.forecast_power_kw to be shipped as an integer

Fixes #22

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
