### PR TITLE
amend name for Auth0 audience var

### DIFF
--- a/src/india_api/internal/config/env.py
+++ b/src/india_api/internal/config/env.py
@@ -60,4 +60,4 @@ class Config(EnvParser):
     DB_URL: str = ""
     PORT: int = 8000
     AUTH0_DOMAIN: str = ""
-    AUTH0_AUDIENCE: str = ""
+    AUTH0_API_AUDIENCE: str = ""


### PR DESCRIPTION
# Pull Request

## Description

Fix mismatching name for new env var `AUTH0_API_AUDIENCE`

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
