### PR TITLE
use day-ahead forecast by default

### DIFF
--- a/src/india_api/internal/service/server.py
+++ b/src/india_api/internal/service/server.py
@@ -182,7 +182,7 @@ def get_forecast_timeseries_route(
         db: DBClientDependency,
         auth: dict = Depends(auth),
         # TODO: add auth scopes
-        forecast_horizon: ForecastHorizon = ForecastHorizon.latest,
+        forecast_horizon: ForecastHorizon = ForecastHorizon.day_ahead,
 ) -> GetForecastGenerationResponse:
     """Function for the forecast generation route."""
     values: list[PredictedPower] = []


### PR DESCRIPTION
# Pull Request

## Description

Use day-ahead forecast horizon by default

Fixes #

## How Has This Been Tested?

CI test

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
