### PR TITLE
pin     "numpy==1.26.4"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pytz >= 2023.3",
     "structlog >= 23.2.0",
     "uvicorn >= 0.24.0",
+    "numpy==1.26.4"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Pull Request

## Description

Pin back to numpy<2.0.0. 

I think this wil solve this error
<img width="1058" alt="Screenshot 2024-06-17 at 11 45 38" src="https://github.com/openclimatefix/india-api/assets/34686298/853fdab9-e87f-48e7-a9bf-2b529bd268c7">


Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
