### PR TITLE
add option to smooth the forecast, dont do this for DA csv

### DIFF
--- a/src/india_api/internal/inputs/indiadb/client.py
+++ b/src/india_api/internal/inputs/indiadb/client.py
@@ -57,6 +57,7 @@ class Client(internal.DatabaseInterface):
         asset_type: SiteAssetType,
         forecast_horizon: ForecastHorizon = ForecastHorizon.latest,
         forecast_horizon_minutes: Optional[int] = None,
+        smooth_flag: bool = True,
     ) -> list[internal.PredictedPower]:
         """Gets the predicted power production for a location.
 
@@ -65,6 +66,7 @@ class Client(internal.DatabaseInterface):
             asset_type: The type of asset to get the forecast for
             forecast_horizon: The time horizon to get the data for. Can be latest or day ahead
             forecast_horizon_minutes: The number of minutes to get the forecast for. forecast_horizon must be 'horizon'
+            smooth_flag: Flag to smooth the forecast
         """
 
         # Get the window
@@ -115,7 +117,8 @@ class Client(internal.DatabaseInterface):
         ]
 
         # smooth the forecasts
-        values = smooth_forecast(values)
+        if smooth_flag:
+            values = smooth_forecast(values)
 
         return values
 
@@ -160,6 +163,7 @@ class Client(internal.DatabaseInterface):
         location: str,
         forecast_horizon: ForecastHorizon = ForecastHorizon.latest,
         forecast_horizon_minutes: Optional[int] = None,
+        smooth_flag: bool = True,
     ) -> [internal.PredictedPower]:
         """
         Gets the predicted solar power production for a location.
@@ -168,6 +172,7 @@ class Client(internal.DatabaseInterface):
             location: The location to get the predicted solar power production for.
             forecast_horizon: The time horizon to get the data for. Can be latest or day ahead
             forecast_horizon_minutes: The number of minutes to get the forecast for. forecast_horizon must be 'horizon'
+            smooth_flag: Flag to smooth the forecast
         """
 
         return self.get_predicted_power_production_for_location(
@@ -175,6 +180,7 @@ class Client(internal.DatabaseInterface):
             asset_type=SiteAssetType.pv,
             forecast_horizon=forecast_horizon,
             forecast_horizon_minutes=forecast_horizon_minutes,
+            smooth_flag=True,
         )
 
     def get_predicted_wind_power_production_for_location(
@@ -182,6 +188,7 @@ class Client(internal.DatabaseInterface):
         location: str,
         forecast_horizon: ForecastHorizon = ForecastHorizon.latest,
         forecast_horizon_minutes: Optional[int] = None,
+        smooth_flag: bool = True,
     ) -> list[internal.PredictedPower]:
         """
         Gets the predicted wind power production for a location.
@@ -190,6 +197,7 @@ class Client(internal.DatabaseInterface):
             location: The location to get the predicted wind power production for.
             forecast_horizon: The time horizon to get the data for. Can be latest or day ahead
             forecast_horizon_minutes: The number of minutes to get the forecast for. forecast_horizon must be 'horizon'
+            smooth_flag: Flag to smooth the forecast
         """
 
         return self.get_predicted_power_production_for_location(
@@ -197,6 +205,7 @@ class Client(internal.DatabaseInterface):
             asset_type=SiteAssetType.wind,
             forecast_horizon=forecast_horizon,
             forecast_horizon_minutes=forecast_horizon_minutes,
+            smooth_flag=smooth_flag
         )
 
     def get_actual_solar_power_production_for_location(

--- a/src/india_api/internal/models.py
+++ b/src/india_api/internal/models.py
@@ -92,6 +92,7 @@ class DatabaseInterface(abc.ABC):
         location: str,
         forecast_horizon: ForecastHorizon = ForecastHorizon.latest,
         forecast_horizon_minutes: Optional[int] = None,
+        smooth_flag: bool = True,
     ) -> list[PredictedPower]:
         """Returns a list of predicted solar power production for a given location."""
         pass
@@ -107,6 +108,7 @@ class DatabaseInterface(abc.ABC):
         location: str,
         forecast_horizon: ForecastHorizon = ForecastHorizon.latest,
         forecast_horizon_minutes: Optional[int] = None,
+        smooth_flag: bool = True,
     ) -> list[PredictedPower]:
         """Returns a list of predicted wind power production for a given location."""
         pass

--- a/src/india_api/internal/service/regions.py
+++ b/src/india_api/internal/service/regions.py
@@ -144,9 +144,12 @@ def get_forecast_timeseries_route(
         region: The region to get the forecast for.
         forecast_horizon: The time horizon to get the data for. Can be 'latest', 'horizon' or 'day ahead'
         forecast_horizon_minutes: The number of minutes to get the forecast for. forecast_horizon must be 'horizon'
-        smooth_flag: If the forecast should be smoothed or not.
+        smooth_flag: If the forecast should be smoothed or not. Note for DA forecast this is always False.
     """
     values: list[PredictedPower] = []
+
+    if forecast_horizon == ForecastHorizon.day_ahead:
+        smooth_flag = False
 
     try:
         if source == "wind":

--- a/src/india_api/internal/service/regions.py
+++ b/src/india_api/internal/service/regions.py
@@ -135,6 +135,7 @@ def get_forecast_timeseries_route(
     # TODO: add auth scopes
     forecast_horizon: ForecastHorizon = ForecastHorizon.day_ahead,
     forecast_horizon_minutes: Optional[int] = None,
+    smooth_flag: bool = True,
 ) -> GetForecastGenerationResponse:
     """Function for the forecast generation route.
 
@@ -143,6 +144,7 @@ def get_forecast_timeseries_route(
         region: The region to get the forecast for.
         forecast_horizon: The time horizon to get the data for. Can be 'latest', 'horizon' or 'day ahead'
         forecast_horizon_minutes: The number of minutes to get the forecast for. forecast_horizon must be 'horizon'
+        smooth_flag: If the forecast should be smoothed or not.
     """
     values: list[PredictedPower] = []
 
@@ -152,12 +154,14 @@ def get_forecast_timeseries_route(
                 location=region,
                 forecast_horizon=forecast_horizon,
                 forecast_horizon_minutes=forecast_horizon_minutes,
+                smooth_flag=smooth_flag,
             )
         elif source == "solar":
             values = db.get_predicted_solar_power_production_for_location(
                 location=region,
                 forecast_horizon=forecast_horizon,
                 forecast_horizon_minutes=forecast_horizon_minutes,
+                smooth_flag=smooth_flag,
             )
     except Exception as e:
         raise HTTPException(
@@ -184,7 +188,7 @@ def get_forecast_da_csv(
     """
 
     forcasts: GetForecastGenerationResponse = get_forecast_timeseries_route(
-        source=source, region=region, db=db, auth=auth, forecast_horizon=ForecastHorizon.day_ahead
+        source=source, region=region, db=db, auth=auth, forecast_horizon=ForecastHorizon.day_ahead, smooth_flag=False
     )
 
     # format to dataframe


### PR DESCRIPTION
# Pull Request

## Description

Add option not to smooth
Don't smooth for DA forecast for csv

This is so we can easily compare internal dashboard with API results. Note we need this for latest, due to zigzag effect

## How Has This Been Tested?

CI test

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
