### PR TITLE
Fix Docker Image Name and Update Setup Instructions (#44)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@ so there is nothing to configure.
 
 ### Using docker
 
-Download the latest image from github container regiimage from github container registry:
+You can either download the latest image from GitHub container registry:
 
 ```sh
 $ docker run ghcr.io/openclimatefix/india-api:latest
+```
+
+Or build and run locally using the Containerfile:
+
+```sh
+$ docker build -t india-api .
+$ docker run india-api
 ```
 
 ### Using python(v3.11.x)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ so there is nothing to configure.
 Download the latest image from github container regiimage from github container registry:
 
 ```sh
-$ docker run ghcr.io/openclimatefix/fake-api:latest
+$ docker run ghcr.io/openclimatefix/india-api:latest
 ```
 
 ### Using python(v3.11.x)


### PR DESCRIPTION
## Description

This update fixes the issue of Docker not pulling the latest image (#44). The Docker image name has been corrected from `fake-api` to `india-api`. Additionally, instructions for setting up Docker locally and using the `Containerfile` have been updated, along with the inclusion of a `.dockerignore` file to optimize the Docker build process. 

### Changes:
- Added a `.dockerignore` file to exclude unnecessary files from the Docker build context.
- Updated the README with correct Docker image name and instructions for local setup using the `Containerfile`.
- Adjusted Docker-related documentation to reflect the updated process.

Fixes #44.

## How Has This Been Tested?

- Verified Docker pull with the corrected image name: `ghcr.io/openclimatefix/india-api:latest`.
- Tested building and running the Docker image locally using the `Containerfile`.

## Checklist:
- [x] Code follows [[OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)](https://github.com/openclimatefix/.github/blob/main/coding_style.md).
- [x] Performed a self-review of the code.
- [x] Updated documentation to reflect changes.
- [x] Verified that the `.dockerignore` file optimizes the build context.
- [x] Tested Docker pull and local build functionality.