### PR TITLE
add horizon to csv route & format func

### DIFF
--- a/src/india_api/internal/inputs/indiadb/test_csv.py
+++ b/src/india_api/internal/inputs/indiadb/test_csv.py
@@ -1,0 +1,69 @@
+import logging
+
+import pandas as pd
+from fastapi import HTTPException
+import pytest
+
+from india_api.internal import PredictedPower, ActualPower, SiteProperties
+
+from pvsite_datamodel.sqlmodels import APIRequestSQL
+
+from .client import Client
+from .conftest import forecast_values
+from ...models import ForecastHorizon
+from ...service.csv import format_csv_and_created_time
+
+log = logging.getLogger(__name__)
+
+# TODO add list of test that are here
+
+
+@pytest.fixture()
+def client(engine, db_session):
+    """Hooks Client into pytest db_session fixture"""
+    client = Client(database_url=str(engine.url))
+    client.session = db_session
+
+    return client
+
+class TestCsvExport:
+    def test_format_csv_and_created_time(self, client, forecast_values_wind) -> None:
+        """Test the format_csv_and_created_time function."""
+        forecast_values_wind = client.get_predicted_wind_power_production_for_location(
+            location="testID"
+        )
+        assert forecast_values_wind is not None
+        assert len(forecast_values_wind) > 0
+        assert isinstance(forecast_values_wind[0], PredictedPower)
+
+        result = format_csv_and_created_time(
+            forecast_values_wind,
+            ForecastHorizon.latest,
+        )
+        assert isinstance(result, tuple)
+        assert isinstance(result[0], pd.DataFrame)
+        assert isinstance(result[1], pd.Timestamp)
+        logging.info(f"CSV created at: {result[1]}")
+        logging.info(f"CSV content: {result[0].head()}")
+        # Check the shape of the DataFrame
+        # The shape should match the number of forecast values
+        # and the number of columns in the DataFrame
+        # The DataFrame should have 3 columns: Date [IST], Time, PowerMW
+        assert result[0].shape[1] == 3
+        # Check the first row of the DataFrame
+        # The date of the first row should be the nearest rounded 15min from now
+        rounded_15_min = pd.Timestamp.now(tz="Asia/Kolkata").round("15min")
+        assert result[0].iloc[0]["Time"] == rounded_15_min.strftime("%H:%M")
+        # Check the number of rows in the DataFrame
+        # For the latest forecast, it should be the number of
+        # forecast values after now
+        forecast_values_from_now = [
+            value for value in forecast_values_wind if value.Time >= rounded_15_min
+        ]
+        assert result[0].shape[0] == len(forecast_values_from_now)
+        # Check the column names
+        assert list(result[0].columns) == ["Date [IST]", "Time", "PowerMW"]
+        # Check the data types of the columns
+        assert result[0]["Date [IST]"].dtype == "datetime64[ns, Asia/Kolkata]"
+        assert result[0]["Time"].dtype == "object"
+        assert result[0]["PowerMW"].dtype == "float64"


### PR DESCRIPTION
# Pull Request

## Description

Add forecast horizon params to CSV route to allow for `latest` and `forecast_horizon` as well as `day_ahead`.
>N.B. This will change the default behaviour of the route to be `latest`, in line with other API routes unless specified in the query parameters.

Fixes #

## How Has This Been Tested?

- [x] Test to follow next week.
- [x] _If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
